### PR TITLE
Clean up import statements for commands to improve readability

### DIFF
--- a/src/commands/Fun/advice.js
+++ b/src/commands/Fun/advice.js
@@ -1,7 +1,7 @@
 // Dependencies
-const fetch = require('node-fetch'),
-	{ EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const fetch = require('node-fetch');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Advice command

--- a/src/commands/Fun/fact.js
+++ b/src/commands/Fun/fact.js
@@ -1,8 +1,8 @@
 // Dependencies
-const fs = require('fs'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const fs = require('fs');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Fact command

--- a/src/commands/Fun/flip.js
+++ b/src/commands/Fun/flip.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Flip command

--- a/src/commands/Fun/meme.js
+++ b/src/commands/Fun/meme.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Meme command

--- a/src/commands/Fun/pokemon.js
+++ b/src/commands/Fun/pokemon.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Pokemon command

--- a/src/commands/Fun/random-caps.js
+++ b/src/commands/Fun/random-caps.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Flip command

--- a/src/commands/Fun/random.js
+++ b/src/commands/Fun/random.js
@@ -1,7 +1,7 @@
 // Dependencies
-const max = 100000,
-	{ EmbedBuilder, Colors, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const max = 100000;
+const { EmbedBuilder, Colors, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Random command

--- a/src/commands/Fun/reminder.js
+++ b/src/commands/Fun/reminder.js
@@ -1,9 +1,9 @@
 // Dependencies
-const ms = require('ms'),
-	{ MessageAttachment, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ timeEventSchema } = require('../../database/models'),
-	{ time: { getTotalTime }, Embed } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const ms = require('ms');
+const { MessageAttachment, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { timeEventSchema } = require('../../database/models');
+const { time: { getTotalTime }, Embed } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * Reminder command

--- a/src/commands/Fun/screenshot.js
+++ b/src/commands/Fun/screenshot.js
@@ -1,8 +1,8 @@
 // Dependencies
-const Puppeteer = require('puppeteer'),
-	{ AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	validUrl = require('valid-url'),
-	Command = require('../../structures/Command.js');
+const Puppeteer = require('puppeteer');
+const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const validUrl = require('valid-url');
+const Command = require('../../structures/Command.js');
 
 /**
  * Screenshot command

--- a/src/commands/Fun/urban.js
+++ b/src/commands/Fun/urban.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { define } = require('urban-dictionary'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Embed } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { define } = require('urban-dictionary');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { Embed } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * Urban command

--- a/src/commands/Giveaway/g-delete.js
+++ b/src/commands/Giveaway/g-delete.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Giveaway delete command

--- a/src/commands/Giveaway/g-edit.js
+++ b/src/commands/Giveaway/g-edit.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { time: { getTotalTime } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { time: { getTotalTime } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Giveaway edit command

--- a/src/commands/Giveaway/g-pause.js
+++ b/src/commands/Giveaway/g-pause.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Giveaway pause command

--- a/src/commands/Giveaway/g-reroll.js
+++ b/src/commands/Giveaway/g-reroll.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Giveaway reroll command

--- a/src/commands/Giveaway/g-start.js
+++ b/src/commands/Giveaway/g-start.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { time: { getTotalTime } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ ChannelType } = require('discord-api-types/v10'),
-	Command = require('../../structures/Command.js');
+const { time: { getTotalTime } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { ChannelType } = require('discord-api-types/v10');
+const Command = require('../../structures/Command.js');
 
 /**
  * Giveaway start command

--- a/src/commands/Giveaway/giveaway.js
+++ b/src/commands/Giveaway/giveaway.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Giveaway start command

--- a/src/commands/Guild/avatar.js
+++ b/src/commands/Guild/avatar.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags }, GuildMember } = require('discord.js'),
-	{ ChannelType } = require('discord-api-types/v10'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags }, GuildMember } = require('discord.js');
+const { ChannelType } = require('discord-api-types/v10');
+const Command = require('../../structures/Command.js');
 
 /**
  * Avatar command

--- a/src/commands/Guild/dashboard.js
+++ b/src/commands/Guild/dashboard.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { ActionRowBuilder, ButtonBuilder, ButtonStyle, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Dashboard command

--- a/src/commands/Guild/discrim.js
+++ b/src/commands/Guild/discrim.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Discrim command

--- a/src/commands/Guild/emoji-list.js
+++ b/src/commands/Guild/emoji-list.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Emoji-list command

--- a/src/commands/Guild/firstmessage.js
+++ b/src/commands/Guild/firstmessage.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ ChannelType } = require('discord-api-types/v10'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { ChannelType } = require('discord-api-types/v10');
+const Command = require('../../structures/Command.js');
 
 /**
  * Firstmessage command

--- a/src/commands/Guild/guildicon.js
+++ b/src/commands/Guild/guildicon.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Guildicon command

--- a/src/commands/Guild/poll.js
+++ b/src/commands/Guild/poll.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Poll command

--- a/src/commands/Guild/role-info.js
+++ b/src/commands/Guild/role-info.js
@@ -1,9 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	moment = require('moment'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags },
-	} = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const moment = require('moment');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Role-info command

--- a/src/commands/Guild/server-info.js
+++ b/src/commands/Guild/server-info.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	moment = require('moment'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const moment = require('moment');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Server-info command

--- a/src/commands/Guild/user-info.js
+++ b/src/commands/Guild/user-info.js
@@ -1,9 +1,9 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	moment = require('moment'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags }, GuildMember } = require('discord.js'),
-	{ ChannelType } = require('discord-api-types/v10'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const moment = require('moment');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags }, GuildMember } = require('discord.js');
+const { ChannelType } = require('discord-api-types/v10');
+const Command = require('../../structures/Command.js');
 
 /**
  * User-info command

--- a/src/commands/Host/eval.js
+++ b/src/commands/Host/eval.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { inspect } = require('util'),
-	{ EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require ('discord.js'),
-	Command = require('../../structures/Command.js');
+const { inspect } = require('util');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require ('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Eval command

--- a/src/commands/Host/lavalink.js
+++ b/src/commands/Host/lavalink.js
@@ -1,8 +1,8 @@
 // Dependencies
-const	{ Embed } = require('../../utils'),
-	{ Node } = require('erela.js'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { Node } = require('erela.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Lavalink command

--- a/src/commands/Host/refresh.js
+++ b/src/commands/Host/refresh.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { ApplicationCommandType } = require('discord-api-types/v10'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandType } = require('discord-api-types/v10');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Docs command

--- a/src/commands/Host/reload.js
+++ b/src/commands/Host/reload.js
@@ -1,9 +1,9 @@
 // Dependencies
-const { promisify } = require('util'),
-	readdir = promisify(require('fs').readdir),
-	path = require('path'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { promisify } = require('util');
+const readdir = promisify(require('fs').readdir);
+const path = require('path');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Reload command

--- a/src/commands/Host/script.js
+++ b/src/commands/Host/script.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ promisify, inspect } = require('util'),
-	readdir = promisify(require('fs').readdir),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { promisify, inspect } = require('util');
+const readdir = promisify(require('fs').readdir);
+const Command = require('../../structures/Command.js');
 
 /**
  * Script command

--- a/src/commands/Host/shutdown.js
+++ b/src/commands/Host/shutdown.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Shutdown command

--- a/src/commands/Host/user.js
+++ b/src/commands/Host/user.js
@@ -1,9 +1,9 @@
 // Dependencies
-const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ userSchema } = require('../../database/models'),
-	moment = require('moment'),
-	axios = require('axios'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { userSchema } = require('../../database/models');
+const moment = require('moment');
+const axios = require('axios');
+const Command = require('../../structures/Command.js');
 
 /**
  * User command

--- a/src/commands/Image/blurpify.js
+++ b/src/commands/Image/blurpify.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Blurpify command

--- a/src/commands/Image/captcha.js
+++ b/src/commands/Image/captcha.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Captcha command

--- a/src/commands/Image/cat.js
+++ b/src/commands/Image/cat.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Cat command

--- a/src/commands/Image/changemymind.js
+++ b/src/commands/Image/changemymind.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * ChangeMyMind command

--- a/src/commands/Image/clyde.js
+++ b/src/commands/Image/clyde.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Clyde command

--- a/src/commands/Image/deepfry.js
+++ b/src/commands/Image/deepfry.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Deepfry command

--- a/src/commands/Image/dog.js
+++ b/src/commands/Image/dog.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Dog command

--- a/src/commands/Image/generate.js
+++ b/src/commands/Image/generate.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Embed } = require('../../utils'),
-	{ post } = require('axios'),
-	Command = require('../../structures/Command.js');
+const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { Embed } = require('../../utils');
+const { post } = require('axios');
+const Command = require('../../structures/Command.js');
 
 // image types
 const image_1 = ['3000years', 'approved', 'beautiful', 'brazzers', 'burn', 'challenger', 'circle', 'contrast', 'crush', 'ddungeon', 'dictator', 'distort', 'emboss', 'fire', 'frame', 'gay',

--- a/src/commands/Image/image.js
+++ b/src/commands/Image/image.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { image_search } = require('duckduckgo-images-api'),
-	{ Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, ChannelType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { image_search } = require('duckduckgo-images-api');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, ChannelType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Image command

--- a/src/commands/Image/phcomment.js
+++ b/src/commands/Image/phcomment.js
@@ -1,8 +1,8 @@
 // Dependencies
-const	{ Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const	{ Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * PHcomment command

--- a/src/commands/Image/qrcode.js
+++ b/src/commands/Image/qrcode.js
@@ -1,7 +1,7 @@
 // Dependencies
-const	{ AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Embed } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { Embed } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * QRCode command

--- a/src/commands/Image/ship.js
+++ b/src/commands/Image/ship.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ship command

--- a/src/commands/Image/stickbug.js
+++ b/src/commands/Image/stickbug.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	fetch = require('node-fetch'),
-	Command = require('../../structures/Command.js');
+const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const fetch = require('node-fetch');
+const Command = require('../../structures/Command.js');
 
 /**
  * Stickbug command

--- a/src/commands/Image/threats.js
+++ b/src/commands/Image/threats.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Threats command

--- a/src/commands/Image/twitter.js
+++ b/src/commands/Image/twitter.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Twitter command

--- a/src/commands/Image/whowouldwin.js
+++ b/src/commands/Image/whowouldwin.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * WhoWouldWin command

--- a/src/commands/Level/leaderboard.js
+++ b/src/commands/Level/leaderboard.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed, paginate } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, paginate } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 // Show the ordinal for the ranks
 // eslint-disable-next-line no-sparse-arrays

--- a/src/commands/Level/rank.js
+++ b/src/commands/Level/rank.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Rank: rank } = require('canvacord'),
-	Command = require('../../structures/Command.js');
+const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { Rank: rank } = require('canvacord');
+const Command = require('../../structures/Command.js');
 
 /**
  * Rank command

--- a/src/commands/Misc/about.js
+++ b/src/commands/Misc/about.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { version, ChannelType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Embed, time: { getReadableTime }, functions: { genInviteLink } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { version, ChannelType, PermissionsBitField: { Flags } } = require('discord.js');
+const { Embed, time: { getReadableTime }, functions: { genInviteLink } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * About command

--- a/src/commands/Misc/help.js
+++ b/src/commands/Misc/help.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Help command

--- a/src/commands/Misc/invite.js
+++ b/src/commands/Misc/invite.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ functions: { genInviteLink } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const { functions: { genInviteLink } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * Invite command

--- a/src/commands/Misc/privacy.js
+++ b/src/commands/Misc/privacy.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Privacy command

--- a/src/commands/Misc/shorturl.js
+++ b/src/commands/Misc/shorturl.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { shorten } = require('tinyurl'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { shorten } = require('tinyurl');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * ShortURL command

--- a/src/commands/Misc/status.js
+++ b/src/commands/Misc/status.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Status command

--- a/src/commands/Misc/support.js
+++ b/src/commands/Misc/support.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Support command

--- a/src/commands/Misc/uptime.js
+++ b/src/commands/Misc/uptime.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ time: { getReadableTime } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { time: { getReadableTime } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Uptime command

--- a/src/commands/Moderation/addrole.js
+++ b/src/commands/Moderation/addrole.js
@@ -1,7 +1,7 @@
 // Dependencies
-const fs = require('fs'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const fs = require('fs');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Addrole command

--- a/src/commands/Moderation/ban.js
+++ b/src/commands/Moderation/ban.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed, time: { getTotalTime } } = require('../../utils'),
-	{ timeEventSchema } = require('../../database/models'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, time: { getTotalTime } } = require('../../utils');
+const { timeEventSchema } = require('../../database/models');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ban command

--- a/src/commands/Moderation/clear-warning.js
+++ b/src/commands/Moderation/clear-warning.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { WarningSchema } = require('../../database/models'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { WarningSchema } = require('../../database/models');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * ClearWarning command

--- a/src/commands/Moderation/clear.js
+++ b/src/commands/Moderation/clear.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ActionRowBuilder, ButtonBuilder, ButtonStyle, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Clear command

--- a/src/commands/Moderation/deafen.js
+++ b/src/commands/Moderation/deafen.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Deafen command

--- a/src/commands/Moderation/delrole.js
+++ b/src/commands/Moderation/delrole.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Delrole command

--- a/src/commands/Moderation/dm.js
+++ b/src/commands/Moderation/dm.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * DM command

--- a/src/commands/Moderation/editrole.js
+++ b/src/commands/Moderation/editrole.js
@@ -1,7 +1,7 @@
 // Dependencies
-const fs = require('fs'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const fs = require('fs');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Editrole command

--- a/src/commands/Moderation/kick.js
+++ b/src/commands/Moderation/kick.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Kick command

--- a/src/commands/Moderation/lock.js
+++ b/src/commands/Moderation/lock.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ ChannelType } = require('discord-api-types/v10'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { ChannelType } = require('discord-api-types/v10');
+const Command = require('../../structures/Command.js');
 
 /**
  * Lock command

--- a/src/commands/Moderation/mute.js
+++ b/src/commands/Moderation/mute.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { time: { getTotalTime } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { time: { getTotalTime } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Mute command

--- a/src/commands/Moderation/nick.js
+++ b/src/commands/Moderation/nick.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Nick command

--- a/src/commands/Moderation/report.js
+++ b/src/commands/Moderation/report.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Report command

--- a/src/commands/Moderation/slowmode.js
+++ b/src/commands/Moderation/slowmode.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { time: { getTotalTime, getReadableTime } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { time: { getTotalTime, getReadableTime } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Slowmode command

--- a/src/commands/Moderation/unban.js
+++ b/src/commands/Moderation/unban.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Unban command

--- a/src/commands/Moderation/undeafen.js
+++ b/src/commands/Moderation/undeafen.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Undeafen command

--- a/src/commands/Moderation/unlock.js
+++ b/src/commands/Moderation/unlock.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ ChannelType } = require('discord-api-types/v10'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { ChannelType } = require('discord-api-types/v10');
+const Command = require('../../structures/Command.js');
 
 /**
  * Unlock command

--- a/src/commands/Moderation/unmute.js
+++ b/src/commands/Moderation/unmute.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Unmute command

--- a/src/commands/Moderation/warn.js
+++ b/src/commands/Moderation/warn.js
@@ -1,6 +1,6 @@
 // Dependencies
-const	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Warn command

--- a/src/commands/Moderation/warnings.js
+++ b/src/commands/Moderation/warnings.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ WarningSchema } = require('../../database/models'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { WarningSchema } = require('../../database/models');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Warnings command

--- a/src/commands/Music/247.js
+++ b/src/commands/Music/247.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * TwentyFourSeven command

--- a/src/commands/Music/autoplay.js
+++ b/src/commands/Music/autoplay.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Autoplay command

--- a/src/commands/Music/back.js
+++ b/src/commands/Music/back.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Back command

--- a/src/commands/Music/bassboost.js
+++ b/src/commands/Music/bassboost.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ functions: { checkMusic } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { functions: { checkMusic } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * Bassboost command

--- a/src/commands/Music/dc.js
+++ b/src/commands/Music/dc.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Disconnect command

--- a/src/commands/Music/fast-forward.js
+++ b/src/commands/Music/fast-forward.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed, time: { read24hrFormat, getReadableTime }, functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, time: { read24hrFormat, getReadableTime }, functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Addrole command

--- a/src/commands/Music/join.js
+++ b/src/commands/Music/join.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Join command

--- a/src/commands/Music/loop.js
+++ b/src/commands/Music/loop.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Loop command

--- a/src/commands/Music/lyrics.js
+++ b/src/commands/Music/lyrics.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed, paginate } = require('../../utils'),
-	{ getSong } = require('genius-lyrics-api'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, paginate } = require('../../utils');
+const { getSong } = require('genius-lyrics-api');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Lyrics command

--- a/src/commands/Music/move.js
+++ b/src/commands/Music/move.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Move command

--- a/src/commands/Music/nightcore.js
+++ b/src/commands/Music/nightcore.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ functions: { checkMusic } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const { functions: { checkMusic } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * Nightcore command

--- a/src/commands/Music/np.js
+++ b/src/commands/Music/np.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ splitBar } = require('string-progressbar'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { splitBar } = require('string-progressbar');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * NowPlaying command

--- a/src/commands/Music/p-add.js
+++ b/src/commands/Music/p-add.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { PlaylistSchema } = require('../../database/models'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PlaylistSchema } = require('../../database/models');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * playlist add command

--- a/src/commands/Music/p-create.js
+++ b/src/commands/Music/p-create.js
@@ -1,9 +1,9 @@
 // Dependencies
-const	{ Embed } = require('../../utils'),
-	{ PlaylistSchema } = require('../../database/models'),
-	{ time: { getReadableTime } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PlaylistSchema } = require('../../database/models');
+const { time: { getReadableTime } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * playlist create command

--- a/src/commands/Music/p-delete.js
+++ b/src/commands/Music/p-delete.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { PlaylistSchema } = require('../../database/models'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PlaylistSchema } = require('../../database/models');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * playlist delete command

--- a/src/commands/Music/p-load.js
+++ b/src/commands/Music/p-load.js
@@ -1,9 +1,9 @@
 // Dependencies
-const	{ Embed } = require('../../utils'),
-	{ PlaylistSchema } = require('../../database/models'),
-	{ TrackUtils } = require('erela.js'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const	{ Embed } = require('../../utils');
+const { PlaylistSchema } = require('../../database/models');
+const { TrackUtils } = require('erela.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * playlist load command

--- a/src/commands/Music/p-remove.js
+++ b/src/commands/Music/p-remove.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { PlaylistSchema } = require('../../database/models'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PlaylistSchema } = require('../../database/models');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * playlist remove command

--- a/src/commands/Music/p-view.js
+++ b/src/commands/Music/p-view.js
@@ -1,10 +1,10 @@
 // Dependencies
-const	{ Embed } = require('../../utils'),
-	{ PlaylistSchema } = require('../../database/models'),
-	{ time: { getReadableTime } } = require('../../utils'),
-	{ paginate } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PlaylistSchema } = require('../../database/models');
+const { time: { getReadableTime } } = require('../../utils');
+const { paginate } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * playlist view command

--- a/src/commands/Music/pause.js
+++ b/src/commands/Music/pause.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * pause command

--- a/src/commands/Music/pitch.js
+++ b/src/commands/Music/pitch.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ functions: { checkMusic } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { functions: { checkMusic } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * pitch command

--- a/src/commands/Music/play.js
+++ b/src/commands/Music/play.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * play command

--- a/src/commands/Music/previous.js
+++ b/src/commands/Music/previous.js
@@ -1,9 +1,9 @@
 // Dependencies
-const { paginate } = require('../../utils'),
-	{ Embed } = require('../../utils'),
-	{ time: { getReadableTime } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { paginate } = require('../../utils');
+const { Embed } = require('../../utils');
+const { time: { getReadableTime } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * previous command

--- a/src/commands/Music/queue.js
+++ b/src/commands/Music/queue.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { paginate, Embed, time: { getReadableTime } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { paginate, Embed, time: { getReadableTime } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * queue command

--- a/src/commands/Music/radio.js
+++ b/src/commands/Music/radio.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ getStations } = require('radio-browser'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { getStations } = require('radio-browser');
+const Command = require('../../structures/Command.js');
 
 /**
  * radio command

--- a/src/commands/Music/remove.js
+++ b/src/commands/Music/remove.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * remove command

--- a/src/commands/Music/resume.js
+++ b/src/commands/Music/resume.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * resume command

--- a/src/commands/Music/rewind.js
+++ b/src/commands/Music/rewind.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed, time: { read24hrFormat, getReadableTime }, functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, time: { read24hrFormat, getReadableTime }, functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * rewind command

--- a/src/commands/Music/search.js
+++ b/src/commands/Music/search.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * search command

--- a/src/commands/Music/seek.js
+++ b/src/commands/Music/seek.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ time: { read24hrFormat }, functions: { checkMusic } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { time: { read24hrFormat }, functions: { checkMusic } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * seek command

--- a/src/commands/Music/shuffle.js
+++ b/src/commands/Music/shuffle.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ functions: { checkMusic } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const { functions: { checkMusic } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * shuffle command

--- a/src/commands/Music/skip.js
+++ b/src/commands/Music/skip.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * skip command

--- a/src/commands/Music/speed.js
+++ b/src/commands/Music/speed.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed, functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * speed command

--- a/src/commands/Music/tts.js
+++ b/src/commands/Music/tts.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * TTS command

--- a/src/commands/Music/vaporwave.js
+++ b/src/commands/Music/vaporwave.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ functions: { checkMusic } } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { EmbedBuilder, PermissionsBitField: { Flags } } = require('discord.js');
+const { functions: { checkMusic } } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * vaporwave command

--- a/src/commands/Music/volume.js
+++ b/src/commands/Music/volume.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed, functions: { checkMusic } } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed, functions: { checkMusic } } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * back command

--- a/src/commands/NSFW/4k.js
+++ b/src/commands/NSFW/4k.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * 4k command

--- a/src/commands/NSFW/anal.js
+++ b/src/commands/NSFW/anal.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Anal command

--- a/src/commands/NSFW/ass.js
+++ b/src/commands/NSFW/ass.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ass command

--- a/src/commands/NSFW/boobs.js
+++ b/src/commands/NSFW/boobs.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Boobs command

--- a/src/commands/NSFW/gonewild.js
+++ b/src/commands/NSFW/gonewild.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Gonewild command

--- a/src/commands/NSFW/hneko.js
+++ b/src/commands/NSFW/hneko.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Hneko command

--- a/src/commands/NSFW/pgif.js
+++ b/src/commands/NSFW/pgif.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Pgif command

--- a/src/commands/NSFW/pussy.js
+++ b/src/commands/NSFW/pussy.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Pussy command

--- a/src/commands/NSFW/thigh.js
+++ b/src/commands/NSFW/thigh.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { get } = require('axios'),
-	{ Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { get } = require('axios');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Thigh command

--- a/src/commands/Plugins/rr-add.js
+++ b/src/commands/Plugins/rr-add.js
@@ -1,8 +1,8 @@
 // Dependencies
-const Command = require('../../structures/Command.js'),
-	{ ReactionRoleSchema } = require('../../database/models'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Embed } = require('../../utils');
+const Command = require('../../structures/Command.js');
+const { ReactionRoleSchema } = require('../../database/models');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const { Embed } = require('../../utils');
 
 /**
  * Reaction role add command

--- a/src/commands/Plugins/rr-remove.js
+++ b/src/commands/Plugins/rr-remove.js
@@ -1,7 +1,7 @@
 // Dependencies
-const Command = require('../../structures/Command.js'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	{ ReactionRoleSchema } = require('../../database/models');
+const Command = require('../../structures/Command.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const { ReactionRoleSchema } = require('../../database/models');
 
 /**
  * Reaction role remove command

--- a/src/commands/Plugins/set-lang.js
+++ b/src/commands/Plugins/set-lang.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { MessageActionRow, MessageSelectMenu, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { MessageActionRow, MessageSelectMenu, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 
 const flags = {

--- a/src/commands/Plugins/set-logs.js
+++ b/src/commands/Plugins/set-logs.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 // List of events
 const features = ['CHANNELCREATE', 'CHANNELDELETE', 'CHANNELUPDATE', 'EMOJICREATE', 'EMOJIDELETE', 'EMOJIUPDATE',

--- a/src/commands/Plugins/set-plugin.js
+++ b/src/commands/Plugins/set-plugin.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * set plugin command

--- a/src/commands/Searcher/fortnite.js
+++ b/src/commands/Searcher/fortnite.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Fortnite command

--- a/src/commands/Searcher/mc.js
+++ b/src/commands/Searcher/mc.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { status } = require('minecraft-server-util'),
-	{ AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	{ Embed } = require('../../utils'),
-	Command = require('../../structures/Command.js');
+const { status } = require('minecraft-server-util');
+const { AttachmentBuilder, ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const { Embed } = require('../../utils');
+const Command = require('../../structures/Command.js');
 
 /**
  * MC command

--- a/src/commands/Searcher/r6.js
+++ b/src/commands/Searcher/r6.js
@@ -1,10 +1,10 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	R6API = require('r6api.js').default,
-	config = require('../../config.js'),
-	{ findByUsername, getProgression, getRanks, getStats } = new R6API({ email: config.api_keys.rainbow.email, password: config.api_keys.rainbow.password }),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const R6API = require('r6api.js').default;
+const config = require('../../config.js');
+const { findByUsername, getProgression, getRanks, getStats } = new R6API({ email: config.api_keys.rainbow.email, password: config.api_keys.rainbow.password });
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 const platforms = { pc: 'uplay', xbox: 'xbl', ps4: 'psn' };
 const regions = { eu: 'emea', na: 'ncsa', as: 'apac' };

--- a/src/commands/Searcher/reddit.js
+++ b/src/commands/Searcher/reddit.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Reddit command

--- a/src/commands/Searcher/steam.js
+++ b/src/commands/Searcher/steam.js
@@ -1,9 +1,9 @@
 // Dependencies
-const fetch = require('node-fetch'),
-	dateFormat = require('dateformat'),
-	{ Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const fetch = require('node-fetch');
+const dateFormat = require('dateformat');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Steam command

--- a/src/commands/Searcher/twitch.js
+++ b/src/commands/Searcher/twitch.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	fetch = require('node-fetch'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const fetch = require('node-fetch');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 // access token to interact with twitch API
 let access_token = null;

--- a/src/commands/Searcher/weather.js
+++ b/src/commands/Searcher/weather.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { find } = require('weather-js'),
-	{ Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { find } = require('weather-js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Weather command

--- a/src/commands/Tags/tag-add.js
+++ b/src/commands/Tags/tag-add.js
@@ -1,7 +1,7 @@
 // Dependencies
-const	{ TagsSchema } = require('../../database/models/index.js'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { TagsSchema } = require('../../database/models/index.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Tag add command

--- a/src/commands/Tags/tag-delete.js
+++ b/src/commands/Tags/tag-delete.js
@@ -1,7 +1,7 @@
 // Dependencies
-const	{ TagsSchema } = require('../../database/models/index.js'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { TagsSchema } = require('../../database/models/index.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Tag delete command

--- a/src/commands/Tags/tag-edit.js
+++ b/src/commands/Tags/tag-edit.js
@@ -1,7 +1,7 @@
 // Dependencies
-const	{ TagsSchema } = require('../../database/models/index.js'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { TagsSchema } = require('../../database/models/index.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Tag edit command

--- a/src/commands/Tags/tag-view.js
+++ b/src/commands/Tags/tag-view.js
@@ -1,8 +1,8 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ TagsSchema } = require('../../database/models/index.js'),
-	{ PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { TagsSchema } = require('../../database/models/index.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Tag view command

--- a/src/commands/Tags/tags.js
+++ b/src/commands/Tags/tags.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Tags command

--- a/src/commands/Ticket/ticket-close.js
+++ b/src/commands/Ticket/ticket-close.js
@@ -1,6 +1,6 @@
 // Dependencies
-const { PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ticket close command

--- a/src/commands/Ticket/ticket-create.js
+++ b/src/commands/Ticket/ticket-create.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ticket create command

--- a/src/commands/Ticket/ticket-setup.js
+++ b/src/commands/Ticket/ticket-setup.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ApplicationCommandOptionType, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ticket setup command

--- a/src/commands/Ticket/ticket.js
+++ b/src/commands/Ticket/ticket.js
@@ -1,7 +1,7 @@
 // Dependencies
-const { Embed } = require('../../utils'),
-	{ ActionRowBuilder, ApplicationCommandOptionType, ButtonBuilder, ButtonStyle, PermissionsBitField: { Flags } } = require('discord.js'),
-	Command = require('../../structures/Command.js');
+const { Embed } = require('../../utils');
+const { ActionRowBuilder, ApplicationCommandOptionType, ButtonBuilder, ButtonStyle, PermissionsBitField: { Flags } } = require('discord.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * Ticket command

--- a/src/commands/command.example.js
+++ b/src/commands/command.example.js
@@ -1,5 +1,5 @@
 // Dependencies
-const	Command = require('../../structures/Command.js');
+const Command = require('../../structures/Command.js');
 
 /**
  * CustomCommand command


### PR DESCRIPTION
Each imported module has its own line instead of being comma-separated.